### PR TITLE
It is better to have a repository field in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ version = "0.3.1"
 authors = ["Mika Sanchez <keyneom122@hotmail.com>"]
 edition = "2021"
 license = "MIT"
+repository = "https://github.com/keyneom/minchash"
 
 [dependencies]
 k256 = "0.11"


### PR DESCRIPTION
To allow [Crates.io](https://crates.io/), [lib.rs](https://lib.rs/) and the [Rust Digger](https://rust-digger.code-maven.com/) to link to it. See [the manifest](https://doc.rust-lang.org/cargo/reference/manifest.htm|#the-repository-field) for the explanation.